### PR TITLE
cicd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,16 +4,27 @@ on:
 
 jobs:
   Deploy:
-    name: Deploy
+    name: 'Deploy'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: 'Checkout'
         uses: actions/checkout@v4
 
-      - name: Setup Go toolchain
+      - name: 'Setup Go toolchain'
         uses: actions/setup-go@v5
         with: 
           go-version: '1.22'
 
-      - name: Build
-        run: ./scripts/buildprod.sh
+      - name: 'Build'
+        run: './scripts/buildprod.sh'
+
+      - name: 'GCP Auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-cgloud@v2'
+
+      - name: 'Deploy image'
+        run: 'gcloud builds submit --tag us-central1-docker.pkg.dev/skilled-index-425616-q0/notely-ar-repo/notely .'


### PR DESCRIPTION
- **fix: Paper over the security vuln in json.go**
- **chore: go fmt**
- **fix: Possible slow attack in main**
- **chore: Add cd.yml with basic deploy step**
- **fix: Missing go version for gh actions workflow**
- **chore: Remove extraneous push trigger for ci**
- **chore: Update cd.yml with GCP registry commands**
